### PR TITLE
Prevent basic HTML injection in .toString()

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -64,7 +64,7 @@ FakeSVG.prototype.toString = function() {
 	}
 	str += '>';
 	if(typeof this.children == 'string') {
-		str += this.children;
+		str += this.children.replace('<', '&lt;');
 	} else {
 		this.children.forEach(function(e) {
 			str += e;


### PR DESCRIPTION
See https://github.com/tabatkins/railroad-diagrams/commit/52b8ed70c9540c741f589c76b56046111701a1ac#commitcomment-2170089

Is this enough, or should more characters be escaped? What about attributes?
