### PR TITLE
Allow both intrinsic sizing and scaling to the parent’s width.

### DIFF
--- a/example.html
+++ b/example.html
@@ -7,12 +7,16 @@ h1 {
 	font-family: sans-serif;
 	font-size: 1em;
 }
+div svg.railroad-diagram {
+	width: 80%;  /* Scale to the width of the parent */
+	height: 100%;  /* Preserve the ratio. Could be related to https://bugs.webkit.org/show_bug.cgi?id=82489 */
+}
 </style>
 <link rel='stylesheet' href='railroad-diagrams.css'>
 <script src='railroad-diagrams.js'></script>
 <body>
 <h1 id='ident'>IDENT</h1>
-<div style="width: 50%">
+<div>
 <script >
 Diagram(
 	Choice(0, Skip(), '-'),

--- a/railroad-diagrams.css
+++ b/railroad-diagrams.css
@@ -1,6 +1,5 @@
 svg.railroad-diagram {
     background-color: hsl(30,20%,95%);
-    max-height: 100%     /*WebKit hack for https://bugs.webkit.org/show_bug.cgi?id=82489*/
 }
 svg.railroad-diagram path {
     stroke-width: 3;

--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -43,7 +43,7 @@ var temp = (function(options) {
 	}
 
 	function wrapString(value) {
-	    return ((typeof value) == 'string') ? new Terminal(value) : value;
+		return ((typeof value) == 'string') ? new Terminal(value) : value;
 	}
 
 
@@ -190,17 +190,17 @@ var temp = (function(options) {
 				x += 10;
 			}
 		}
-		var viewBoxWidth = this.width + paddingl + paddingr;
-        var viewBoxHeight = this.up + this.down + paddingt + paddingb;
-        this.attrs.viewBox = "0 0 "  + viewBoxWidth + " " + viewBoxHeight;
+		this.attrs.width = this.width + paddingl + paddingr;
+		this.attrs.height = this.up + this.down + paddingt + paddingb;
+		this.attrs.viewBox = "0 0 "  + this.attrs.width + " " + this.attrs.height;
 		g.addTo(this);
 		this.formatted = true;
 		return this;
 	}
 	Diagram.prototype.addTo = function(parent) {
-        var scriptTag = document.getElementsByTagName('script');
-        scriptTag = scriptTag[scriptTag.length - 1];
-        var parentTag = scriptTag.parentNode;
+		var scriptTag = document.getElementsByTagName('script');
+		scriptTag = scriptTag[scriptTag.length - 1];
+		var parentTag = scriptTag.parentNode;
 		parent = parent || parentTag;
 		return this.$super.addTo.call(this, parent);
 	}


### PR DESCRIPTION
As discussed in #9 with @rparree , have both width/height and viewBox attributes.

As far as I understand, setting CSS 'height' to a percentage (even though that resolves to 'auto') triggers this part of the SVG spec, so that the used height is not just the "height" attribute.

http://www.w3.org/TR/SVG/coords.html#ViewportSpace

> if there are positioning properties specified on the referencing element or on the outermost svg element that are sufficient to establish the height of the viewport, then these positioning properties establish the viewport's height; otherwise, the ‘height’ attribute on the outermost svg element establishes the viewport's height.

Blink, Gecko and Presto seem to be consistent there, but I don’t quite understand what makes the ratio be preserved. In particular, any percentage value gives the same result.

Keep the part of #9 that fixes #3.
