### PR TITLE
Fixed Diagram format method parameters being ignored.

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -170,9 +170,9 @@ var temp = (function(options) {
 	}
 	Diagram.prototype.format = function(paddingt, paddingr, paddingb, paddingl) {
 		paddingt = unnull(paddingt, 20);
-		paddingr = unnull(paddingt, 20);
-		paddingb = unnull(paddingt, 20);
-		paddingl = unnull(paddingr, 20);
+		paddingr = unnull(paddingr, 20);
+		paddingb = unnull(paddingb, 20);
+		paddingl = unnull(paddingl, 20);
 		var x = paddingl;
 		var y = paddingt;
 		y += this.up;


### PR DESCRIPTION
The Diagram format method parameters paddingr, paddingb, paddingl were either ignored or misassigned. It usually went unnoticed as padding values are often the same.  
