### PR TITLE
Fix the up/down method call on Diagram

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -160,8 +160,8 @@ var temp = (function(options) {
 		this.items.unshift(new Start);
 		this.items.push(new End);
 		this.width = this.items.reduce(function(sofar, el) { return sofar + el.width + (el.needsSpace?20:0)}, 0)+1;
-		this.up = Math.max.apply(this.items.map(function(x){return x.up}));
-		this.down = Math.max.apply(this.items.map(function(x){return x.down}));
+		this.up = Math.max.apply(null, this.items.map(function (x) { return x.up; }));
+		this.down = Math.max.apply(null, this.items.map(function (x) { return x.down; }));
 		this.formatted = false;
 	}
 	subclassOf(Diagram, FakeSVG);


### PR DESCRIPTION
After updating from the latest commit, I got many errors (even on the example and generator pages). It seems that I was a few version behind and still had the "old" version of up/down reduce in Diagram. The new version is lacking the first parameter from apply_, resulting with a *-Infinity_ for _up_ and _down_. I hesitated between _null_ and _this_, but I can't figure a case where _this_ would be required here. 
