### PR TITLE
Changed single `replace` into global `replace`.

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -93,11 +93,11 @@ var temp = (function(options) {
 	FakeSVG.prototype.toString = function() {
 		var str = '<' + this.tagName;
 		for(var attr in this.attrs) {
-			str += ' ' + attr + '="' + (this.attrs[attr]+'').replace('&', '&amp;').replace('"', '&quot;') + '"';
+			str += ' ' + attr + '="' + (this.attrs[attr]+'').replace(/&/g, '&amp;').replace(/"/g, '&quot;') + '"';
 		}
 		str += '>\n';
 		if(typeof this.children == 'string') {
-			str += this.children.replace('&', '&amp;').replace('<', '&lt;');
+			str += this.children.replace(/&/g, '&amp;').replace(/</g, '&lt;');
 		} else {
 			this.children.forEach(function(e) {
 				str += e;


### PR DESCRIPTION
The generated SVG contained non-escaped meta characters: `"<<="` was being changed into `"&lt;<="`. Changed all `replace('...', '...')` into `replace(/.../g, '...')`.
