### PR TITLE
Add support for node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "railroad-diagrams",
+  "version": "1.0.0",
+  "description": "A small JS+SVG library for drawing railroad syntax diagrams.",
+  "main": "railroad-diagrams.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tabatkins/railroad-diagrams.git"
+  },
+  "keywords": [
+    "railroad",
+    "syntax",
+    "diagrams",
+    "grammar",
+    "svg"
+  ],
+  "author": "Tab Atkins Jr.",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/tabatkins/railroad-diagrams/issues"
+  },
+  "homepage": "https://github.com/tabatkins/railroad-diagrams"
+}

--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -22,7 +22,7 @@ As well, several configuration constants are passed into the module function at 
 At runtime, these constants can be found on the Diagram class.
 */
 
-var temp = (function(options) {
+(function(options) {
 	function subclassOf(baseClass, superClass) {
 		baseClass.prototype = Object.create(superClass.prototype);
 		baseClass.prototype.$super = superClass.prototype;
@@ -490,9 +490,30 @@ var temp = (function(options) {
 		Path(x,y).right(width).addTo(this);
 		return this;
 	}
+	
+	var root;
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		root = {};
+		define([], function() {
+			return root;
+		});
+	} else if (typeof exports === 'object') {
+		// CommonJS for node
+		root = exports;
+	} else {
+		// Browser globals (root is window)
+		root = this;
+	}
 
-return [Diagram, ComplexDiagram, Sequence, Choice, Optional, OneOrMore, ZeroOrMore, Terminal, NonTerminal, Comment, Skip]
-})(
+	var temp = [Diagram, ComplexDiagram, Sequence, Choice, Optional, OneOrMore, ZeroOrMore, Terminal, NonTerminal, Comment, Skip];
+	/*
+	These are the names that the internal classes are exported as.
+	If you would like different names, adjust them here.
+	*/
+	['Diagram', 'ComplexDiagram', 'Sequence', 'Choice', 'Optional', 'OneOrMore', 'ZeroOrMore', 'Terminal', 'NonTerminal', 'Comment', 'Skip']
+		.forEach(function(e,i) { root[e] = temp[i]; });
+}).call(this,
 	{
 	VERTICAL_SEPARATION: 8,
 	ARC_RADIUS: 10,
@@ -501,10 +522,3 @@ return [Diagram, ComplexDiagram, Sequence, Choice, Optional, OneOrMore, ZeroOrMo
 	INTERNAL_ALIGNMENT: 'center',
 	}
 );
-
-/*
-These are the names that the internal classes are exported as.
-If you would like different names, adjust them here.
-*/
-['Diagram', 'ComplexDiagram', 'Sequence', 'Choice', 'Optional', 'OneOrMore', 'ZeroOrMore', 'Terminal', 'NonTerminal', 'Comment', 'Skip']
-	.forEach(function(e,i) { window[e] = temp[i]; });


### PR DESCRIPTION
Adds a wrapper to support javascript module systems (AMD, CommonJS). If there is no module loader it still works and attaches the functions into the global window object.
I also added a package.json so it can be conveniently installed using `npm install railroad-diagrams`.

Solves #10 
