### PR TITLE
Added classes to allow styling of Terminal, NonTerminal

### DIFF
--- a/railroad-diagrams.css
+++ b/railroad-diagrams.css
@@ -16,6 +16,9 @@ svg.railroad-diagram text.label {
 svg.railroad-diagram text.comment {
     font: italic 12px monospace;
 }
+svg.railroad-diagram g.non-terminal text {
+    /*font-style: italic;*/
+}
 svg.railroad-diagram rect {
     stroke-width: 3;
     stroke: black;

--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -415,7 +415,7 @@ At runtime, these constants can be found on the Diagram class.
 
 	function Terminal(text) {
 		if(!(this instanceof Terminal)) return new Terminal(text);
-		FakeSVG.call(this, 'g');
+		FakeSVG.call(this, 'g', {'class': 'terminal'});
 		this.text = text;
 		this.width = text.length * 8 + 20; /* Assume that each char is .5em, and that the em is 16px */
 		this.up = 11;
@@ -437,7 +437,7 @@ At runtime, these constants can be found on the Diagram class.
 
 	function NonTerminal(text) {
 		if(!(this instanceof NonTerminal)) return new NonTerminal(text);
-		FakeSVG.call(this, 'g');
+		FakeSVG.call(this, 'g', {'class': 'non-terminal'});
 		this.text = text;
 		this.width = text.length * 8 + 20;
 		this.up = 11;

--- a/railroad_diagrams.py
+++ b/railroad_diagrams.py
@@ -330,7 +330,7 @@ class End(DiagramItem):
 
 class Terminal(DiagramItem):
     def __init__(self, text):
-        DiagramItem.__init__(self, 'g')
+        DiagramItem.__init__(self, 'g', {'class': 'terminal'})
         self.text = text
         self.width = len(text) * CHARACTER_ADVANCE + 20
         self.up = 11
@@ -355,7 +355,7 @@ class Terminal(DiagramItem):
 
 class NonTerminal(DiagramItem):
     def __init__(self, text):
-        DiagramItem.__init__(self, 'g')
+        DiagramItem.__init__(self, 'g', {'class': 'non-terminal'})
         self.text = text
         self.width = len(text) * CHARACTER_ADVANCE + 20
         self.up = 11


### PR DESCRIPTION
Classes are added to the group containing the text elements for greater flexibility.

This allows to change the appearance of the different types of nodes using CSS only.