### PR TITLE
remove leading and trailing lines from sequences

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -262,8 +262,12 @@ At runtime, these constants can be found on the Diagram class.
 			throw new RangeError("Stack() must only occur at the very last position of Sequence().");
 		}
 		this.items = items.map(wrapString);
-		this.width = this.items.reduce(function(sofar, el) { return sofar + el.width + (el.needsSpace?20:0)}, 0);
+		var numberOfItems = this.items.length;
+		this.width = this.items.reduce(function(sofar, el, i) {
+			return sofar + el.width + (el.needsSpace && i > 0 ? 10 : 0) + (el.needsSpace && i < numberOfItems-1 ? 10 : 0);
+		}, 0);
 		this.offsetX = 0;
+		this.needsSpace = true;
 		this.height = this.items.reduce(function(sofar, el) { return sofar + el.height }, 0);
 		this.up = this.items.reduce(function(sofar,el) { return Math.max(sofar, el.up)}, 0);
 		this.down = this.items.reduce(function(sofar,el) { return Math.max(sofar, el.down)}, 0);
@@ -278,14 +282,14 @@ At runtime, these constants can be found on the Diagram class.
 
 		for(var i = 0; i < this.items.length; i++) {
 			var item = this.items[i];
-			if(item.needsSpace) {
+			if(item.needsSpace && i > 0) {
 				Path(x,y).h(10).addTo(this);
 				x += 10;
 			}
 			item.format(x, y, item.width).addTo(this);
 			x += item.width;
 			y += item.height;
-			if(item.needsSpace) {
+			if(item.needsSpace && i < this.items.length-1) {
 				Path(x,y).h(10).addTo(this);
 				x += 10;
 			}


### PR DESCRIPTION
This change remove the leading and trailing lines from sequences so lines are only added between the individual elements but not at the beginning and the end.

The diagrams look a bit more "condensed" but that could be addressed in the choice operator (if necessary)

this should fix #32 

comparison: left aligned UNICODE-RANGE example before (top) and after the patch (bottom)
![railroad_ 32_unicode_before_after](https://cloud.githubusercontent.com/assets/8081379/9396347/920cc2fe-4794-11e5-874c-db856c7d4bfa.png)
