### PR TITLE
this -> self in python code

### DIFF
--- a/railroad_diagrams.py
+++ b/railroad_diagrams.py
@@ -246,9 +246,9 @@ class Stack(DiagramItem):
         for i,item in enumerate(self.items):
             self.height += item.height
             if i > 0:
-                this.height += max(ARC_RADIUS*2, item.up + VERTICAL_SEPARATION)
+                self.height += max(ARC_RADIUS*2, item.up + VERTICAL_SEPARATION)
             if i < last:
-                this.height += max(ARC_RADIUS*2, item.down + VERTICAL_SEPARATION)
+                self.height += max(ARC_RADIUS*2, item.down + VERTICAL_SEPARATION)
         if DEBUG:
             self.attrs['data-updown'] = "{0} {1} {2}".format(self.up, self.height, self.down)
             self.attrs['data-type'] = "stack"


### PR DESCRIPTION
@tabatkins Small fix to the python `Stack` implementation. It seems in converting from JS to Python, two `this` entries weren't set `self`. 

Thanks for writing this library!