### PR TITLE
allow option-object in toString to insert namespace and style

### DIFF
--- a/railroad-diagrams.js
+++ b/railroad-diagrams.js
@@ -109,13 +109,20 @@ At runtime, these constants can be found on the Diagram class.
 		}
 		return el;
 	};
-	FakeSVG.prototype.toString = function() {
+	FakeSVG.prototype.toString = function(opt) {
+        opt=opt||{};
 		var str = '<' + this.tagName;
-		var group = this.tagName == "g" || this.tagName == "svg";
+        var group = this.tagName == "g" || this.tagName == "svg";
+        if(this.tagName == "svg" && opt.svgattr){
+            str += ' '+opt.svgattr;
+        }
 		for(var attr in this.attrs) {
 			str += ' ' + attr + '="' + (this.attrs[attr]+'').replace(/&/g, '&amp;').replace(/"/g, '&quot;') + '"';
 		}
-		str += '>';
+        str += '>';
+        if(this.tagName == "svg" && opt.css){
+            str += '\n<style><![CDATA[\n'+opt.css+'\n]]></style>';
+        }
 		if(group) str += "\n";
 		if(typeof this.children == 'string') {
 			str += FakeSVG.prototype.escapeString(this.children);
@@ -272,11 +279,11 @@ At runtime, these constants can be found on the Diagram class.
 		}
 		return this.$super.toSVG.call(this);
 	}
-	Diagram.prototype.toString = function() {
+	Diagram.prototype.toString = function(opt) {
 		if (!this.formatted) {
 			this.format();
 		}
-		return this.$super.toString.call(this);
+		return this.$super.toString.call(this,opt);
 	}
 
 	function ComplexDiagram() {


### PR DESCRIPTION
solves #36 in a generic way

```javascript
const css=[
    '.railroad-diagram {',
    '    background-color: hsl(30,20%,95%);',
    '}',
    '.railroad-diagram path {',
    '    stroke-width: 3;',
    '    stroke: black;',
    '    fill: rgba(0,0,0,0);',
    '}',
    '.railroad-diagram text {',
    '    font: bold 14px monospace;',
    '    text-anchor: middle;',
    '}',
    '.railroad-diagram text.label {',
    '    text-anchor: start;',
    '}',
    '.railroad-diagram text.comment {',
    '    font: italic 12px monospace;',
    '}',
    '.railroad-diagram rect {',
    '    stroke-width: 3;',
    '    stroke: black;',
    '    fill: hsl(120,100%,90%);',
    '}'].join("\n");
const svgattr='xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"';
const standaloneSVG=Diagram().format().toString({css,svgattr});```