### PR TITLE
Preserve whitespace in SVG text nodes.

### DIFF
--- a/railroad-diagrams.css
+++ b/railroad-diagrams.css
@@ -9,6 +9,7 @@ svg.railroad-diagram path {
 svg.railroad-diagram text {
     font: bold 14px monospace;
     text-anchor: middle;
+    white-space: pre;
 }
 svg.railroad-diagram text.diagram-text {
     font-size: 12px;


### PR DESCRIPTION
Currently, whitespace is not preserved in SGV `<text>` nodes, which leads to stuff like this being rendered.

Input:

    Diagram(Terminal('"x"'), Terminal('"      y      "'))

Output:

![output](https://user-images.githubusercontent.com/14198070/56471786-c7966c80-6456-11e9-82e3-40213a0016a3.png)

Expected output:

![expected output](https://user-images.githubusercontent.com/14198070/56471800-0e846200-6457-11e9-8281-9fd8b385c4dd.png)

---

The issue is solved simply by adding `whitespace: pre` to the CSS rules for SVG `<text>` nodes, which is what this PR does.
