### PR TITLE
Generated HTML symbols entities are missing a ';'.

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -19,7 +19,7 @@ COMMENT_CHAR_WIDTH = 7 # comments are in smaller text by default
 
 def e(text):
 	import re
-	return re.sub(r"[*_\`\[\]<&]", lambda c: "&#{0}".format(ord(c.group(0))), unicode(text))
+	return re.sub(r"[*_\`\[\]<&]", lambda c: "&#{0};".format(ord(c.group(0))), unicode(text))
 
 def determineGaps(outer, inner):
 	diff = outer - inner


### PR DESCRIPTION
When diagrams contain a character in this set: [*_\`\[\]<&], railroad.py replaces the character with the equivalent HTML symbol entity, but doesn't add the required ';' character on the end. railroad.js correctly adds the ';'. 