### PR TITLE
Fix typo in railroad.py

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -219,7 +219,7 @@ class Style(DiagramItem):
 		self.needsSpace = False
 
 	def __repr__(self):
-		return 'Style(%r)' % css
+		return 'Style(%r)' % self.css
 
 	def format(self, x, y, width):
 		return self


### PR DESCRIPTION
Without this fix, I get
```
  File "...../python3.6/site-packages/railroad.py", line 222, in __repr__
    return 'Style(%r)' % css
NameError: name 'css' is not defined
```