### PR TITLE
Add a walk_railroad function to railroad.py (and slightly refactor the class hierarchy)

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -84,16 +84,6 @@ class DiagramItem(object):
 		return not (self == other)
 
 
-class DiagramSingleContainer(DiagramItem):
-	def __init__(self, name, item, attrs=None, text=None):
-		DiagramItem.__init__(self, name, attrs, text)
-		self.item = wrapString(item)
-
-	def walk(self, cb):
-		cb(self)
-		self.item.walk(cb)
-
-
 class DiagramMultiContainer(DiagramItem):
 	def __init__(self, name, items, attrs=None, text=None):
 		DiagramItem.__init__(self, name, attrs, text)
@@ -981,9 +971,10 @@ def Optional(item, skip=False):
 	return Choice(0 if skip else 1, Skip(), item)
 
 
-class OneOrMore(DiagramSingleContainer):
+class OneOrMore(DiagramItem):
 	def __init__(self, item, repeat=None):
-		DiagramSingleContainer.__init__(self, 'g', item)
+		DiagramItem.__init__(self, 'g')
+		self.item = wrapString(item)
 		repeat = repeat or Skip()
 		self.rep = wrapString(repeat)
 		self.width = max(self.item.width, self.rep.width) + AR * 2

--- a/railroad.py
+++ b/railroad.py
@@ -81,6 +81,18 @@ class DiagramItem(object):
 		return not (self == other)
 
 
+class DiagramSingleContainer(DiagramItem):
+	def __init__(self, name, item, attrs=None, text=None):
+		DiagramItem.__init__(self, name, attrs, text)
+		self.item = wrapString(item)
+
+
+class DiagramMultiContainer(DiagramItem):
+	def __init__(self, name, items, attrs=None, text=None):
+		DiagramItem.__init__(self, name, attrs, text)
+		self.items = [wrapString(item) for item in items]
+
+
 class Path(DiagramItem):
 	def __init__(self, x, y):
 		self.x = x
@@ -230,12 +242,11 @@ class Style(DiagramItem):
 		write(u'<style>{cdata}</style>'.format(cdata=cdata))
 
 
-class Diagram(DiagramItem):
+class Diagram(DiagramMultiContainer):
 	def __init__(self, *items, **kwargs):
 		# Accepts a type=[simple|complex] kwarg
-		DiagramItem.__init__(self, 'svg', {'class': DIAGRAM_CLASS})
+		DiagramMultiContainer.__init__(self, 'svg', items, {'class': DIAGRAM_CLASS})
 		self.type = kwargs.get("type", "simple")
-		self.items = [wrapString(item) for item in items]
 		if items and not isinstance(items[0], Start):
 			self.items.insert(0, Start(self.type))
 		if items and not isinstance(items[-1], End):
@@ -329,10 +340,9 @@ class Diagram(DiagramItem):
 		}
 
 
-class Sequence(DiagramItem):
+class Sequence(DiagramMultiContainer):
 	def __init__(self, *items):
-		DiagramItem.__init__(self, 'g')
-		self.items = [wrapString(item) for item in items]
+		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = True
 		self.up = 0
 		self.down = 0
@@ -371,10 +381,9 @@ class Sequence(DiagramItem):
 		return self
 
 
-class Stack(DiagramItem):
+class Stack(DiagramMultiContainer):
 	def __init__(self, *items):
-		DiagramItem.__init__(self, 'g')
-		self.items = [wrapString(item) for item in items]
+		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = True
 		self.width = max(item.width + (20 if item.needsSpace else 0) for item in self.items)
 		# pretty sure that space calc is totes wrong
@@ -426,7 +435,7 @@ class Stack(DiagramItem):
 		return self
 
 
-class OptionalSequence(DiagramItem):
+class OptionalSequence(DiagramMultiContainer):
 	def __new__(cls, *items):
 		if len(items) <= 1:
 			return Sequence(*items)
@@ -434,8 +443,7 @@ class OptionalSequence(DiagramItem):
 			return super(OptionalSequence, cls).__new__(cls)
 
 	def __init__(self, *items):
-		DiagramItem.__init__(self, 'g')
-		self.items = [wrapString(item) for item in items]
+		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = False
 		self.width = 0
 		self.up = 0
@@ -535,7 +543,7 @@ class OptionalSequence(DiagramItem):
 					.addTo(self))
 		return self
 
-class AlternatingSequence(DiagramItem):
+class AlternatingSequence(DiagramMultiContainer):
 	def __new__(cls, *items):
 		if len(items) == 2:
 			return super(AlternatingSequence, cls).__new__(cls)
@@ -543,8 +551,7 @@ class AlternatingSequence(DiagramItem):
 			raise Exception("AlternatingSequence takes exactly two arguments got " + len(items))
 
 	def __init__(self, *items):
-		DiagramItem.__init__(self, 'g')
-		self.items = [wrapString(item) for item in items]
+		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = False
 
 		arc = AR
@@ -615,12 +622,11 @@ class AlternatingSequence(DiagramItem):
 		return self
 
 
-class Choice(DiagramItem):
+class Choice(DiagramMultiContainer):
 	def __init__(self, default, *items):
-		DiagramItem.__init__(self, 'g')
+		DiagramMultiContainer.__init__(self, 'g', items)
 		assert default < len(items)
 		self.default = default
-		self.items = [wrapString(item) for item in items]
 		self.width = AR * 4 + max(item.width for item in self.items)
 		self.up = self.items[0].up
 		self.down = self.items[-1].down
@@ -704,15 +710,14 @@ class Choice(DiagramItem):
 		return self
 
 
-class MultipleChoice(DiagramItem):
+class MultipleChoice(DiagramMultiContainer):
 	def __init__(self, default, type, *items):
-		DiagramItem.__init__(self, 'g')
+		DiagramMultiContainer.__init__(self, 'g', items)
 		assert 0 <= default < len(items)
 		assert type in ["any", "all"]
 		self.default = default
 		self.type = type
 		self.needsSpace = True
-		self.items = [wrapString(item) for item in items]
 		self.innerWidth = max(item.width for item in self.items)
 		self.width = 30 + AR + self.innerWidth + AR + 20
 		self.up = self.items[0].up
@@ -826,7 +831,7 @@ class MultipleChoice(DiagramItem):
 		return self
 
 
-class HorizontalChoice(DiagramItem):
+class HorizontalChoice(DiagramMultiContainer):
 	def __new__(cls, *items):
 		if len(items) <= 1:
 			return Sequence(*items)
@@ -834,8 +839,7 @@ class HorizontalChoice(DiagramItem):
 			return super(HorizontalChoice, cls).__new__(cls)
 
 	def __init__(self, *items):
-		DiagramItem.__init__(self, 'g')
-		self.items = [wrapString(item) for item in items]
+		DiagramMultiContainer.__init__(self, 'g', items)
 		allButLast = self.items[:-1]
 		middles = self.items[1:-1]
 		first = self.items[0]
@@ -965,11 +969,10 @@ def Optional(item, skip=False):
 	return Choice(0 if skip else 1, Skip(), item)
 
 
-class OneOrMore(DiagramItem):
+class OneOrMore(DiagramSingleContainer):
 	def __init__(self, item, repeat=None):
-		DiagramItem.__init__(self, 'g')
+		DiagramSingleContainer.__init__(self, 'g', item)
 		repeat = repeat or Skip()
-		self.item = wrapString(item)
 		self.rep = wrapString(repeat)
 		self.width = max(self.item.width, self.rep.width) + AR * 2
 		self.height = self.item.height
@@ -1176,6 +1179,15 @@ class Skip(DiagramItem):
 
 	def __repr__(self):
 		return 'Skip()'
+
+
+def walk_railroad(obj, callback_fn):
+	callback_fn(obj)
+	if isinstance(obj, DiagramSingleContainer):
+		walk_railroad(obj.item, callback_fn)
+	elif isinstance(obj, DiagramMultiContainer):
+		for item in obj.items:
+			walk_railroad(item, callback_fn)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Brief explanation: I've got a `dict()` of fairly complicated inter-related syntax diagrams, and they're now getting so complex I wanted to add some code to "sanity check" them. To do that, I need to iterate through all the nodes in each of the diagrams, and the new `walk_railroad` function allows me to do just that :smiley: 

E.g. my current `callback_fn` looks something like:
```python
def callback(item):
    if isinstance(item, NonTerminal):
        # ... do some checks ...
    elif isinstance(item, Terminal):
        # ... do some other checks ...
```
and then I can do:
```python
for name, diagram in diagrams_dict.items():
    print("Checking {}".format(name))
    walk_railroad(diagram, callback)
```
