### PR TITLE
Add attribute xmlns:xlink="http://www.w3.org/1999/xlink" to standalone output

### DIFF
--- a/railroad.js
+++ b/railroad.js
@@ -303,6 +303,7 @@ export class Diagram extends DiagramMultiContainer {
 		const s = new FakeSVG('style', {}, style || defaultCSS);
 		this.children.push(s);
 		this.attrs.xmlns = "http://www.w3.org/2000/svg";
+		this.attrs['xmlns:xlink'] = "http://www.w3.org/1999/xlink";
 		const result = super.toString.call(this);
 		this.children.pop();
 		delete this.attrs.xmlns;


### PR DESCRIPTION
If a `xlink:href` attribute is used, it has to be declared. It is probably too complicated to check if the attribute is really used before appending the namespace attribute.