### PR TITLE
Fix missing xlink namespace in standalone Python output

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -256,7 +256,8 @@ class Diagram(DiagramMultiContainer):
 			self,
 			'svg',
 			items,
-			{'class': DIAGRAM_CLASS, 'xmlns': "http://www.w3.org/2000/svg"}
+			{'class': DIAGRAM_CLASS, 'xmlns': "http://www.w3.org/2000/svg",
+				'xmlns:xlink': "http://www.w3.org/1999/xlink"}
 		)
 		self.type = kwargs.get("type", "simple")
 		if items and not isinstance(items[0], Start):


### PR DESCRIPTION
The standalone svg produced from the Python version was missing the xlink namespace attribute. It is not missing in the Javascript code.