### PR TITLE
Updated railroad.py to correct OptionalSequence error

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -398,7 +398,7 @@ class Stack(DiagramMultiContainer):
 	def __init__(self, *items):
 		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = True
-		self.width = max(item.width + (20 if item.needsSpace else 0) for item in self.items)
+		self.width = max(item.width + (10 if item.needsSpace else 0) for item in self.items)
 		# pretty sure that space calc is totes wrong
 		if len(self.items) > 1:
 			self.width += AR*2

--- a/railroad.py
+++ b/railroad.py
@@ -398,7 +398,7 @@ class Stack(DiagramMultiContainer):
 	def __init__(self, *items):
 		DiagramMultiContainer.__init__(self, 'g', items)
 		self.needsSpace = True
-		self.width = max(item.width + (10 if item.needsSpace else 0) for item in self.items)
+		self.width = max(item.width + (20 if item.needsSpace else 0) for item in self.items)
 		# pretty sure that space calc is totes wrong
 		if len(self.items) > 1:
 			self.width += AR*2
@@ -468,7 +468,7 @@ class OptionalSequence(DiagramMultiContainer):
 			heightSoFar += item.height
 			if i > 0:
 				self.down = max(self.height + self.down, heightSoFar + max(AR*2, item.down + VS)) - self.height
-			itemWidth = item.width + (20 if item.needsSpace else 0)
+			itemWidth = item.width + (10 if item.needsSpace else 0)
 			if i == 0:
 				self.width += AR + max(itemWidth, AR)
 			else:


### PR DESCRIPTION
tabatkins/railroad-diagrams#87

OPtionalSequence.writeSVG() was adding an extra 10 pixels to the width for each item and leaving a gap in the path before the next container.
