### PR TITLE
[2.0.3] Available from PIP for Ubuntu 18.04 + Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='jackalmage@gmail.com',
     url='https://github.com/tabatkins/railroad-diagrams',
     keywords=['diagrams', 'syntax', 'grammar', 'railroad diagrams'],
+    python_requires=">= 3.7",
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',


### PR DESCRIPTION
From https://github.com/tabatkins/railroad-diagrams/commit/7fc0602821214267eaa8c6c3b0826589a7ccc950 the minimal Python requirement `>= 3.7`, but https://pypi.org/project/railroad-diagrams/2.0.3/ is still availble from PIP for Ubuntu 18.04 + Python 3.6:

    root@748b3d29b97a:~# lsb_release -a
    LSB Version:    core-9.20170808ubuntu1-noarch:security-9.20170808ubuntu1-noarch
    Distributor ID: Ubuntu
    Description:    Ubuntu 18.04.6 LTS
    Release:    18.04
    Codename:   bionic

    root@748b3d29b97a:~# python3 --version
    Python 3.6.9

    root@748b3d29b97a:~# pip list --outdated | grep railroad-diagrams
    railroad-diagrams 1.1.1   2.0.3  wheel

By adding `python_requires=">= 3.7"` to `setup.py` we could prevent this behavior precisely.


Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>