### PR TITLE
Add __repr__ to Pythom Group and HorizonalChoice to fix #101

### DIFF
--- a/railroad.py
+++ b/railroad.py
@@ -1099,6 +1099,10 @@ class HorizontalChoice(DiagramMultiContainer):
                 )
         return self
 
+    def __repr__(self) -> str:
+        items = ", ".join(repr(item) for item in self.items)
+        return f"HorizontalChoice({items})"
+
 
 def Optional(item: Node, skip: bool = False) -> Choice:
     return Choice(0 if skip else 1, Skip(), item)

--- a/railroad.py
+++ b/railroad.py
@@ -1224,7 +1224,7 @@ class Group(DiagramItem):
             self.label.walk(cb)
 
     def __repr__(self) -> str:
-        return f"Group({self.item}, label={self.label})"
+        return f"Group({repr(self.item)}, label={repr(self.label)})"
 
 
 class Start(DiagramItem):

--- a/railroad.py
+++ b/railroad.py
@@ -1219,6 +1219,9 @@ class Group(DiagramItem):
         if self.label:
             self.label.walk(cb)
 
+    def __repr__(self) -> str:
+        return f"Group({self.item}, label={self.label})"
+
 
 class Start(DiagramItem):
     def __init__(self, type: str = "simple", label: Opt[str] = None):


### PR DESCRIPTION
A quick PR to add `__repr__` methods to the Python port's Group and HorizonalChoice classes, to fix issue #101.  I discovered the lack when using `print()` to look at the Python objects created by another program that generates input to this package. 