### PR TITLE
Fix #103: Flake8 config errors due to wrong comment style

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,22 @@
 [flake8]
 ignore =
-    E203, # just fires a bunch on list ranges
-    E265, # don't care
-    E501, # line lengths are a fake idea
-    E722, # bare accept is fine
-    F401, # handling unused imports elsewhere
-    F405, # ditto
-    F811, # flake8 doesn't understand typing overloads
-    W503, # this 'error' is completely backward and will change eventually
+    # just fires a bunch on list ranges
+    E203,
+    # don't care
+    E265,
+    # line lengths are a fake idea
+    E501,
+    # bare accept is fine
+    E722,
+    E743,
+    # handling unused imports elsewhere
+    F401,
+    # ditto
+    F405,
+    # flake8 doesn't understand typing overloads
+    F811,
+    # this 'error' is completely backward and will change eventually
+    W503,
     N802,
     N803,
     N806,


### PR DESCRIPTION
`flake8 railroad.py` produces an exeception: `ValueError: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'` because flake8 does not allow inline comments (ref. https://flake8.pycqa.org/en/latest/user/configuration.html):

> Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
> 
> [flake8]
> per-file-ignores =
>     # imported but unused
>     __init__.py: F401
> this is not:
> 
> [flake8]
> per-file-ignores =
>     __init__.py: F401 # imported but unused
