### PR TITLE
Fix Issue 94 for Python

### DIFF
--- a/README-py.md
+++ b/README-py.md
@@ -13,12 +13,21 @@ and for more non-Python-specific information.)
 Diagrams
 --------
 
-Constructing a diagram is a set of nested calls:
+Constructing a diagram is a set of nested calls.
+To create an SVG diagram:
 
 ```python
 from railroad import Diagram, Choice
 d = Diagram("foo", Choice(0, "bar", "baz"))
 d.writeSvg(sys.stdout.write)
+```
+
+To create a text-format diagram:
+
+```python
+from railroad import Diagram, Choice
+d = Diagram("foo", Choice(0, "bar", "baz"))
+d.writeText(sys.stdout.write)
 ```
 
 A railroad diagram must be started as a `Diagram` object,
@@ -48,6 +57,8 @@ If you don't pass any `css`,
 it'll automatically include the `DEFAULT_STYLE`;
 you can include your own CSS instead by passing it as a string
 (or an empty string to include no CSS at all).
+
+To output the diagram as pre-formatted text, instead of as SVG, call `.writeText(cb)` on it, passing a function that'll get called to write the text.
 
 If you need to walk the component tree of a diagram for some reason, `Diagram` has a `.walk(cb)` method as well, which will call your callback on every node in the diagram, in a "pre-order depth-first traversal" (the node first, then each child).
 
@@ -135,11 +146,12 @@ There are a few options you can tweak, living as UPPERCASE_CONSTANTS at the top 
 Note that if you change the text sizes in the CSS,
 you'll have to adjust the text metrics here as well.
 
-* VS - sets the minimum amount of vertical separation between two items, in CSS px.  Note that the stroke width isn't counted when computing the separation; this shouldn't be relevant unless you have a very small separation or very large stroke width. Defaults to `8`.
-* AR - the radius of the arcs, in CSS px, used in the branching containers like Choice.  This has a relatively large effect on the size of non-trivial diagrams.  Both tight and loose values look good, depending on what you're going for. Defaults to `10`.
-* DIAGRAM_CLASS - the class set on the root `<svg>` element of each diagram, for use in the CSS stylesheet. Defaults to `"railroad-diagram"`.
-* STROKE_ODD_PIXEL_LENGTH - the default stylesheet uses odd pixel lengths for 'stroke'. Due to rasterization artifacts, they look best when the item has been translated half a pixel in both directions. If you change the styling to use a stroke with even pixel lengths, you'll want to set this variable to `False`.
+* VS - sets the minimum amount of vertical separation between two items, in CSS px.  Note that the stroke width isn't counted when computing the separation; this shouldn't be relevant unless you have a very small separation or very large stroke width. Defaults to `8`.  Ignored for text diagrams.
+* AR - the radius of the arcs, in CSS px, used in the branching containers like Choice.  This has a relatively large effect on the size of non-trivial diagrams.  Both tight and loose values look good, depending on what you're going for. Defaults to `10`.  Ignored for text diagrams.
+* DIAGRAM_CLASS - the class set on the root `<svg>` element of each diagram, for use in the CSS stylesheet. Defaults to `"railroad-diagram"`.  Ignored for text diagrams.
+* STROKE_ODD_PIXEL_LENGTH - the default stylesheet uses odd pixel lengths for 'stroke'. Due to rasterization artifacts, they look best when the item has been translated half a pixel in both directions. If you change the styling to use a stroke with even pixel lengths, you'll want to set this variable to `False`.  Ignored for text diagrams.
 * INTERNAL_ALIGNMENT - when some branches of a container are narrower than others, this determines how they're aligned in the extra space.  Defaults to `"center"`, but can be set to `"left"` or `"right"`.
-* CHAR_WIDTH - the approximate width, in CSS px, of characters in normal text (`Terminal` and `NonTerminal`). Defaults to `8.5`.
-* COMMENT_CHAR_WIDTH - the approximate width, in CSS px, of character in `Comment` text, which by default is smaller than the other textual items. Defaults to `7`.
-* DEBUG - if `True`, writes some additional "debug information" into the attributes of elements in the output, to help debug sizing issues. Defaults to `False`.
+* CHAR_WIDTH - the approximate width, in CSS px, of characters in normal text (`Terminal` and `NonTerminal`). Defaults to `8.5`.  Ignored for text diagrams.
+* COMMENT_CHAR_WIDTH - the approximate width, in CSS px, of character in `Comment` text, which by default is smaller than the other textual items. Defaults to `7`.  Ignored for text diagrams.
+* DEBUG - if `True`, writes some additional "debug information" into the attributes of elements in the output, to help debug sizing issues. Defaults to `False`.  Ignored for text diagrams.
+* ESCAPE_HTML - if `True`, causes `Diagram.writeText()` to replace "<". ">", '"', and "&" with their HTML-entity equivalents, so text diagram output can be placed in HTML files unchanged.  Defaults to `True`.

--- a/test.py
+++ b/test.py
@@ -223,3 +223,198 @@ add('Class example',
 		Comment("blue", cls="blue")
 		)
 	)
+
+add('rr-alternatingsequence',
+	Diagram(
+		AlternatingSequence(
+			"foo",
+			"bar"
+			)
+		)
+	)
+
+add('rr-choice',
+	Diagram(
+		Choice(
+			1, "1", "2", "3"
+			)
+		)
+	)
+
+add('rr-group',
+	Diagram(
+		Terminal("foo"),
+		Group(
+			Choice(
+				0, NonTerminal("option 1"), NonTerminal("or two"),
+				)
+			),
+		Terminal("bar")
+		)
+	)
+
+add('rr-horizontalchoice',
+	Diagram(
+		HorizontalChoice(
+			Choice(2, "0", "1", "2", "3", "4"),
+			Choice(2, "5", "6", "7", "8", "9"),
+			Choice(2, "a", "b", "c", "d", "e"),
+			)
+		)
+	)
+
+add('rr-multchoice',
+	Diagram(
+		MultipleChoice(1, "all", "1", "2", "3")
+		)
+	)
+
+add('rr-oneormore',
+	Diagram(
+			OneOrMore("foo", "bar")
+		)
+	)
+
+
+add('rr-optional',
+	Diagram(
+			Optional("foo"),
+			Optional("bar", True),
+		)
+	)
+
+
+add('rr-optionalsequence',
+	Diagram(
+			OptionalSequence("1", "2", "3")
+		)
+	)
+
+
+add('rr-sequence',
+	Diagram(
+			Sequence("1", "2", "3")
+		)
+	)
+
+
+add('rr-stack',
+	Diagram(
+		Stack(
+			"1",
+			"2",
+			"3"
+			)
+		)
+	)
+
+add('rr-title',
+	Diagram(
+			Stack(
+				Terminal("Generate"),
+				Terminal("some"),
+			),
+			OneOrMore(NonTerminal("railroad diagrams"), Comment("and more"))
+		)
+	)
+
+
+add('rr-zeroormore-1',
+	Diagram(
+		ZeroOrMore("foo", Comment("bar"))
+		)
+	)
+
+
+add('rr-zeroormore-2',
+	Diagram(
+		ZeroOrMore("foo", Comment("bar")),
+		ZeroOrMore("foo", Comment("bar"), True)
+		)
+	)
+
+add('complicated-horizontalchoice-1',
+	Diagram(
+		HorizontalChoice(
+			Choice(0, "1", "2", "3", "4", "5"),
+			Choice(4, "1", "2", "3", "4", "5"),
+			Choice(2, "1", "2", "3", "4", "5"),
+			Choice(3, "1", "2", "3", "4", "5"),
+			Choice(1, "1", "2", "3", "4", "5")
+			),
+		HorizontalChoice("1", "2", "3", "4", "5")
+		)
+	)
+
+add('complicated-horizontalchoice-2',
+	Diagram(
+		HorizontalChoice(
+			Choice(0, "1", "2", "3", "4"),
+			"4",
+			Choice(3, "1", "2", "3", "4"),
+			)
+		)
+	)
+
+add('complicated-horizontalchoice-3',
+	Diagram(
+		HorizontalChoice(
+			Choice(0, "1", "2", "3", "4"),
+			Stack("1", "2", "3"),
+			Choice(3, "1", "2", "3", "4"),
+			)
+		)
+	)
+
+add('complicated-horizontalchoice-4',
+	Diagram(
+		HorizontalChoice(
+			Choice(0, "1", "2", "3", "4"),
+			Choice(3, "1", "2", "3", "4"),
+			Stack("1", "2", "3"),
+			)
+		)
+	)
+
+add('complicated-horizontalchoice-5',
+	Diagram(
+		HorizontalChoice(
+			Stack("1", "2", "3"),
+			Choice(0, "1", "2", "3", "4"),
+			Choice(3, "1", "2", "3", "4"),
+			)
+		)
+	)
+
+add('single-stack',
+	Diagram(
+		Stack("1"),
+		)
+	)
+
+add('complicated-optionalsequence-1',
+	Diagram(
+			OptionalSequence("1", Choice(2, "2", "3", "4", "5"), Stack("6", "7", "8", "9", "10"), "11")
+		)
+	)
+
+add('labeled-start',
+	Diagram(
+			Start(label="Labeled Start"),
+			Sequence("1", "2", "3")
+		)
+	)
+
+add('complex',
+	Diagram(
+			Sequence("1", "2", "3"),
+			type="complex"
+		)
+	)
+
+add('simple',
+	Diagram(
+			Sequence("1", "2", "3"),
+			type="simple"
+		)
+	)


### PR DESCRIPTION
This PR adds support to the Python port for generating text-mode diagrams as an alternative to SVG.  The diagrams can be drawn with either pure-ASCII or Unicode (U+25xx) characters, or with any characters of the user's choosing.  I have compared the SVG and text-mode output for all `test.py` test cases visually, and they all look correct to me.

If this PR is merged, I'll look into porting the final accepted code to the JavaScript version.

Feel free to comment on the code and recommend changes - nobody has seen it before but me :-)

Notes
====
* All changes are to `railroad.py` and `test.py`.
  * No existing code was altered, except in `__main__` (see below).
  * The text format code never alters any data in the diagram classes, and so never affects the behavior of the SVG format code.
  * A number of new test cases were added to `test.py`, to verify correct operation of the text-mode diagrams.
* New class `TextDiagram` added:
  * A `TextDiagram` is a rectangular object of characters, with the following fields:
    * `lines`: The array of characters, in the form of a list of strings.
	  * Each string is a horizontal row.
	  * `lines[0]` is the topmost row, and `lines[0][0]` is the top-left-most character.
    * `height`: The height of the rectangle, in characters.
    * `width`: The width of the rectangle, in characters.
    * `entry`: The _index_ into `lines` of the row where the surrounding diagram enters this sub-diagram.
    * `exit`: The _index_ into `lines` of the row where this sub-diagram exits to the surrounding diagram.
  * `TextDiagram`s are intended to be immutable.
    * The code never alters them, although Python doesn't really support immutable class objects.
  * `TextDiagram` is not intended to by used by users of `railroad`, only by the diagram element classes.
  * All non-instance methods are named starting with an underscore.
    * Some are static methods, others are class methods.
    * They all return something appropriate to their name, usually not a `TextDiagram`.
    * Most are intended only for internal-use by `TextDiagram`, but there are a few exceptions:
      * `_gaps(outerWidth, innerWidth)`: Similar to `determineGaps()`, but measured in characters and therefore dealing with possibly-odd splits.
      * `_getParts(partNames)`: Returns one or more drawing characters by name (see "`parts`" below).
      * `_maxWidth(*args)`: Returns the maximum width of all of its arguments, which may be `int`s, `str`s, lists of `str`s, or `TextDiagram`s.
  * All other methods are "API" methods.
    * They are all named like `something` or `somethingElse`.
    * They all return a new `TextDiagram`, based on the instance, except for `setFormatting()`.
      * `setFormatting()` controls the formatting via its parameters, and returns `None`.
	    * I originally expected there to be more to this, but right now it's just the `parts`.
		* It is possible, through `setFormatting()`, to specify a custom set of drawing characters, or to override some of the standard characters.
    * Some of them are static factory methods, creating a new `TextDiagram` based on their parameters.
    * Most are instance methods, returning a new `TextDiagram` based on the instance.
  * `TextDiagram` has three class variables:
    * `parts`: A dictionary of named drawing characters.  All the code draws the diagrams by obtaining the characters by name from this dictionary.  It is initialized from one of the two pre-defined sets, or can be replaced by `setFormatting()`.
    * `PARTS_ASCII`: A dictionary of drawing characters restricted to the ASCII 7-bit character set.
    * `PARTS_UNICODE`: A dictionary of drawing characters from the Unicode character set, based primarily, but not exclusively, on the 25xx box-drawing plane.
* New `Diagram.writeText()` instance method added to create and output text diagrams.  API is identical to `Diagram.writeSvg()`.
  * Unless this method is called, none of the text format code ever gets executed.
* New instance method `textDiagram()` added to each diagram element:
  * Takes no parameters, and returns a `TextDiagram` for the element, including all the elements it contains.
* New option-constant:
  * `ESCAPE_HTML`: a boolean constant used by `Diagram.writeText()` to decide whether to output raw characters or to replace "<", ">", '"', and "&" with their HTML-entity equivalents.
    * It might be a better idea to make it a parameter to `writeText()`, but I wanted writeText()`'s API to mimic `writeSvg()`'s.
* I made several changes to the `__main__` code, which you can accept or discard as you see fit:
  * Command-line support for specifying the output mode and for filtering the list of `test.py` diagrams to process.
    * Syntax is: `railroad.py MODE TESTNAME1 TESTNAME2 ...`.
      * `MODE` is `svg`, `standalone`, `ascii`, or `unicode`, case-insensitively.  If not specified, it defaults to `svg`.
      * If no `TESTNAME`s are specified, all tests are processed,  Otherwise, only the named tests are processed.
	* Tests are always processed in the order they are defined in `test.py`.
	* Since all arguments are optional, typing just `railroad.py` produces SVG output of all the tests, just like before.
