### PR TITLE
Allow Skip() to occupy space

### DIFF
--- a/README-js.md
+++ b/README-js.md
@@ -77,7 +77,7 @@ The leaves:
     The optional arguments have the same meaning as for Terminal,
     except that the default class is `'comment'`.
 
-* `Skip()` - an empty line
+* `Skip([takeUpSpace])` - an empty line (that can optionally take up space)
 
 * `Start({type, label})` and `End({type})` - the start/end shapes. These are supplied by default, but if you want to supply a label to the diagram, you can create a `Start()` explicitly (as the first child of the Diagram!). The `type` property takes either `"simple"` (the default) or `"complex"`, a la `Diagram()` and `ComplexDiagram()`. All properties are optional.
 

--- a/README-py.md
+++ b/README-py.md
@@ -89,7 +89,7 @@ The leaves:
     The optional arguments have the same meaning as for Terminal,
     except that the default class is `'non-terminal'`.
 
-* Skip() - an empty line
+* Skip([takeUpSpace]) - an empty line (that can optionally take up space)
 
 * Start(type, label) and End(type) - the start/end shapes. These are supplied by default, but if you want to supply a label to the diagram, you can create a Start() explicitly (as the first child of the Diagram!). The "type" attribute takes either "simple" (the default) or "complex", a la Diagram() and ComplexDiagram(). All arguments are optional.
 

--- a/railroad.js
+++ b/railroad.js
@@ -1904,13 +1904,13 @@ funcs.Comment = (...args)=>new Comment(...args);
 
 
 export class Skip extends FakeSVG {
-	constructor() {
+	constructor(takeUpSpace = false) {
 		super('g');
 		this.width = 0;
 		this.height = 0;
 		this.up = 0;
 		this.down = 0;
-		this.needsSpace = false;
+		this.needsSpace = takeUpSpace;
 		if(Options.DEBUG) {
 			this.attrs['data-updown'] = this.up + " " + this.height + " " + this.down;
 			this.attrs['data-type'] = "skip";

--- a/railroad.py
+++ b/railroad.py
@@ -1871,11 +1871,12 @@ class Comment(DiagramItem):
 
 
 class Skip(DiagramItem):
-    def __init__(self) -> None:
+    def __init__(self, takeUpSpace: bool = false) -> None:
         DiagramItem.__init__(self, "g")
         self.width = 0
         self.up = 0
         self.down = 0
+        self.needsSpace = takeUpSpace
         addDebug(self)
 
     def format(self, x: float, y: float, width: float) -> Skip:


### PR DESCRIPTION
Just for a little bit of visual separation, as there's no other (easily identifiable) way of adding horizontal separation.

(I wasn't able to test the Python change, sorry!)
```javascript
Diagram(
	OneOrMore(
		Choice(1,
			Terminal("Foo"),
			Terminal("Bar"),
			Terminal("Baz")
		),
	),
	OneOrMore(
		Sequence(
			Skip(true),
			Choice(1,
				Terminal("Foo"),
				Terminal("Bar"),
				Terminal("Baz")
			),
			Skip(true)
		)
	),
	Skip(true),
	OneOrMore(
		Sequence(
			Skip(true),
			Choice(1,
				Sequence(
					Terminal("Foo"),
					Skip(true)
				),
				Terminal("Bar"),
				Sequence(
					Skip(true),
					Terminal("Baz")
				)
			),
			Skip(true)
		)
	)
)
```
![image](https://github.com/user-attachments/assets/1b128593-28dd-452a-8504-3fe1b953909e)