### PR TITLE
Fix #123 - extra vertical line in HorizontalChoice with Javascript.

### DIFF
--- a/railroad.js
+++ b/railroad.js
@@ -1320,7 +1320,7 @@ export class HorizontalChoice extends DiagramMultiContainer {
 				}
 				lines.push(roundcorner_bot_left + line);
 				for(i = 0; i < baselineToSUIL; i++) {
-					lines.push(line_vertical + " ");
+					lines.push("  ");
 				}
 				lines.push(line + line);
 				var entryTD = new TextDiagram(diagramTD.exit, diagramTD.exit, lines);

--- a/test.py
+++ b/test.py
@@ -454,3 +454,15 @@ add('simple',
 			type="simple"
 		)
 	)
+
+add('issue-123',
+	Diagram(
+			Choice(
+				0,
+				HorizontalChoice("A", "a"),
+				HorizontalChoice("B", "b"),
+				HorizontalChoice("C", "c"),
+				HorizontalChoice("D", "d")
+			)
+		)
+	)


### PR DESCRIPTION
The Javascript version of HorizontalChoice's text mode had a vertical line where the Python version had a blank.  The Python version was correct.